### PR TITLE
Export Grouped

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -56,6 +56,8 @@ module Weigh
   ,weighDispatch
   ,weighFunc
   ,weighAction
+  ,Grouped
+  ,Grouped(..)
   )
   where
 


### PR DESCRIPTION
Weigh export
```Haskell
weighResults :: Weigh a -> IO ([Grouped (Weight,Maybe String)], Config)
```
but not `Grouped` :)

Here is a corrected version