### PR TITLE
Try to fix the bug with multiple function of the same name

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -125,7 +125,7 @@ data Weight =
 -- | Some grouped thing.
 data Grouped a
   = Grouped String [Grouped a]
-  | Singleton String a
+  | Singleton a
   deriving (Eq, Show, Functor, Traversable.Traversable, Foldable.Foldable, Generic)
 instance NFData a => NFData (Grouped a)
 
@@ -286,9 +286,7 @@ validateFunc name !f !x !validate =
 tellAction :: String -> (String -> Action) -> Weigh ()
 tellAction name act =
   Weigh (do prefix <- gets (configPrefix . fst)
-            modify (second (\x -> x ++ [Singleton name $ act $ prefixed prefix])))
-        where
-          prefixed prefix = prefix ++ "/" ++ name
+            modify (second (\x -> x ++ [Singleton $ act (prefix ++ "/" ++ name)])))
 
 -- | Make a grouping of tests.
 wgroup :: String -> Weigh () -> Weigh ()
@@ -481,7 +479,7 @@ report config gs =
     singletons =
       mapMaybe
         (\case
-           Singleton _ v -> Just v
+           Singleton v -> Just v
            _ -> Nothing)
         gs
     groups =

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -9,6 +9,8 @@ import Control.DeepSeq
 import Weigh
 import GHC.Generics
 
+import Data.List (nub)
+
 -- | Weigh integers.
 main :: IO ()
 main =
@@ -17,7 +19,10 @@ main =
         wgroup "IO actions" ioactions
         wgroup "Ints" ints
         wgroup "Structs" struct
-        wgroup "Packing" packing)
+        wgroup "Packing" packing
+        wgroup "fst" aFuncNamedId
+        wgroup "snd" anotherFuncNamedId
+    )
 
 -- | Weigh IO actions.
 ioactions :: Weigh ()
@@ -91,3 +96,9 @@ packing =
   do func "\\x -> HasInt x" (\x -> HasInt x) 5
      func "\\x -> HasUnpacked (HasInt x)" (\x -> HasUnpacked (HasInt x)) 5
      func "\\x -> HasPacked (HasInt x)" (\x -> HasPacked (HasInt x)) 5
+
+aFuncNamedId :: Weigh ()
+aFuncNamedId = func "id" id (1::Int)
+
+anotherFuncNamedId :: Weigh ()
+anotherFuncNamedId = func "id" nub ([1,2,3,4,5,1]::[Int])


### PR DESCRIPTION
Hi,

This is a try to fix #28 

I just interchanged the `Name` field of the `Singleton` data with the `actionName` field of `Action`, making it prefixed by its place in the `grouped` hierarchy, and thus avoid problems with testing functions of the same name in different part of the grouped architecture.

I added a test about it, and it passed successfully.

And since the `Name` field of the `Singleton` data  was not used, I removed it.

I also hide the change from the user, by "striping out" the prefix when printing a weightLabel.