### PR TITLE
Add arguments for children

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -350,10 +350,11 @@ fork act =
        hClose h
        setEnv "WEIGH_CASE" $ show $ [actionName act,fp]
        me <- getExecutablePath
+       args <- getArgs
        (exit, _, err) <-
          readProcessWithExitCode
            me
-           ["+RTS", "-T", "-RTS"]
+           (args ++ ["+RTS", "-T", "-RTS"])
            ""
        case exit of
          ExitFailure {} ->


### PR DESCRIPTION
Children can need arguments from their parents (like configuration for weigh tests)