### PR TITLE
Alternative to `func` that deepseqs the argument first.

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -234,7 +234,7 @@ func' :: (NFData a, NFData b)
       -> (b -> a)
       -> b
       -> Weigh ()
-func' name f x = rnf x `seq` validateFunc name f x (const Nothing)
+func' name !f (force -> !x) = validateFunc name f x (const Nothing)
 
 -- | Weigh an action applied to an argument.
 --

--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -46,6 +46,7 @@ module Weigh
   ,defaultConfig
   -- * Simple combinators
   ,func
+  ,func'
   ,io
   ,value
   ,action
@@ -225,6 +226,15 @@ func :: (NFData a)
      -> b        -- ^ Argument to that function.
      -> Weigh ()
 func name !f !x = validateFunc name f x (const Nothing)
+
+-- | Weigh a function applied to an argument. Unlike 'func', the argument
+-- is evaluated to normal form before the function is applied.
+func' :: (NFData a, NFData b)
+      => String
+      -> (b -> a)
+      -> b
+      -> Weigh ()
+func' name f x = rnf x `seq` validateFunc name f x (const Nothing)
 
 -- | Weigh an action applied to an argument.
 --


### PR DESCRIPTION
Hi there. I've been looking into providing an alternative to `func`, which I've named `func'` for now (suggestions for a better name are encouraged!) that deepseqs the argument to a function before it is weighed. I did a small test with the code below. The results show a significant difference in allocations/gcs when using `func` vs. `func'`. 

I think `func'` is useful because it's important to distinguish the allocations/gcs made by a function being weighed (in this case `sum`) and those made by the computations used to generate the argument to the function being weighed (in this case `leakyList`). The Criterion library has a similar option called `env` that (to the best of my knowledge) addresses the same issue w.r.t. time performance.

Many thanks,
Martin

```
import Weigh
import Control.DeepSeq ( NFData, force )

main :: IO ()
main = mainWith $ do
  func "func 200"    sum (leakyList 200)
  func "func 500"    sum (leakyList 500)
  func "func 1000"   sum (leakyList 1000)

  func' "func' 200"  sum (leakyList 200)
  func' "func' 500"  sum (leakyList 500)
  func' "func' 1000" sum (leakyList 1000)

leakyInt :: Int -> Int
leakyInt n = foldl (+) 0 (replicate n 1)

leakyList :: Int -> [Int]
leakyList n = fmap leakyInt [100 .. n]

func'
  :: (NFData a, NFData b)
  => String
  -> (a -> b)
  -> a
  -> Weigh ()
func' name !f (force -> !x) = func name f x

----------------------------------------------------------------

Case         Allocated  GCs
func 200     1,722,504    1
func 500    13,576,104   12
func 1000   55,732,104   53
func' 200        5,672    0
func' 500       22,472    0
func' 1000      50,472    0
```