### PR TITLE
Process memory usage metric via VmRss from /proc/self/status

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -109,6 +109,7 @@ data Column
   | MaxOS     -- ^ Maximum memory in use by the RTS. Valid only for
               -- GHC >= 8.2.2. For unsupported GHC, this is reported
               -- as 0.
+  | MaxRss    -- ^ Maximum residency memory in use (via OS)
   | WallTime  -- ^ Rough execution time. For general indication, not a benchmark tool.
   deriving (Show, Eq, Enum)
 
@@ -585,6 +586,7 @@ reportTabular config = tabled
       , (Check, (True, "Check"))
       , (Max, (False, "Max"))
       , (MaxOS, (False, "MaxOS"))
+      , (MaxRss, (False, "MaxRss"))
       , (WallTime, (False, "Wall Time"))
       ]
     toRow (w, err) =
@@ -594,6 +596,7 @@ reportTabular config = tabled
       , (Live, (False, commas (weightLiveBytes w)))
       , (Max, (False, commas (weightMaxBytes w)))
       , (MaxOS, (False, commas (weightMaxOSBytes w)))
+      , (MaxRss, (False, commas (weightMaxRssBytes w)))
       , (WallTime, (False, printf "%.3fs" (weightWallTime w)))
       , ( Check
         , ( True

--- a/src/Weigh/OsStats.hs
+++ b/src/Weigh/OsStats.hs
@@ -1,0 +1,32 @@
+module Weigh.OsStats
+  ( getVmRssWithError
+  , getVmRss
+  )
+  where
+
+
+import Text.Read
+import Data.List
+import Data.Word
+
+
+getVmRss :: IO Word64
+getVmRss = either (const 0) id <$> getVmRssWithError
+
+
+-- | Get 'VmRSS' (resident set size) from file "/proc/self/status".
+-- Returns either error message or memory size in bytes.
+--
+getVmRssWithError :: IO (Either String Word64)
+getVmRssWithError = do
+  stat <- readFile "/proc/self/status"
+  return $
+    case filter (isPrefixOf "VmRSS:") $ lines stat of
+      [] -> Left "No VmRSS line in /proc/self/status"
+      (line:_) ->
+        case words line of
+          "VmRSS:":sz:"kB":[] -> (* kb) <$> readEither sz
+          _                   -> Left $ "Can't parse \"" ++ line ++ "\""
+  where
+    kb = 1024
+

--- a/weigh.cabal
+++ b/weigh.cabal
@@ -19,6 +19,7 @@ library
   ghc-options:         -Wall -O2
   exposed-modules:     Weigh
   other-modules:       Weigh.GHCStats
+                     , Weigh.OsStats
   build-depends:       base >= 4.7 && < 5
                      , process
                      , deepseq


### PR DESCRIPTION
Here I add measure of memory used by process with `VmRss` from Linux file `/proc/self/status`.

It can be used to measure FFI-based Haskell programs, when `max_mem_in_use_bytes` from GHC.Stats is not gets any information.