### PR TITLE
Remove dependency on ghc

### DIFF
--- a/weigh.cabal
+++ b/weigh.cabal
@@ -25,9 +25,10 @@ library
                      , mtl
                      , split
                      , temporary
-                     , ghc >= 8.2.1
                      , criterion-measurement
   default-language:    Haskell2010
+  if impl(ghc < 8.2.1)
+    buildable: false
 
 test-suite weigh-test
   default-language:    Haskell2010


### PR DESCRIPTION
This package depends on ghc, which makes it quite difficult to build if you want to use a different version of a dependency of lib:ghc as lib:ghc is currently not reinstallable.

Yet, it seems this package only uses the ghc dependency to set a lower-bound on compatible GHCs. This patch uses Cabal's condition logic instead