### PR TITLE
Import Control.Monad.unless

### DIFF
--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -75,6 +75,7 @@ module Weigh
 import Control.Applicative
 import Control.Arrow
 import Control.DeepSeq
+import Control.Monad (unless)
 import Control.Monad.State
 import Criterion.Measurement
 import qualified Data.Foldable as Foldable


### PR DESCRIPTION
This is necessary for GHC 9.6 compatibility. I ran the tests on GHC 9.6.1, they pass.

Fixes #49 