### PR TITLE
Correct `mtl-2.3` compatibility fix that does not require `CPP`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         - os: ubuntu-latest
           stack-yaml: stack.yaml
           resolver: lts-19
-        - os: macos-latest
+        - os: macos-13
           stack-yaml: stack.yaml
           resolver: lts-19
         - os: windows-latest

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.0.18:
+	* Fix compatibility with `mtl`, whenever different version from the one that is wired with ghc is used.
+
 0.0.17:
 	* Changes to make compatible for GHC 9.6
 

--- a/src/Weigh.hs
+++ b/src/Weigh.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -75,10 +74,8 @@ module Weigh
 import Control.Applicative
 import Control.Arrow
 import Control.DeepSeq
-#if MIN_VERSION_base(4,18,0)
 import Control.Monad (unless)
-#endif
-import Control.Monad.State
+import Control.Monad.State (State, execState, get, gets, modify)
 import Criterion.Measurement
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List


### PR DESCRIPTION
Replacement for #53